### PR TITLE
issue-26 - fixes PHPStan errors

### DIFF
--- a/arbor.info.yml
+++ b/arbor.info.yml
@@ -5,6 +5,9 @@ core_version_requirement: ^10.2 || ^11
 base theme: ui_suite_bootstrap
 hidden: false
 
+dependencies:
+  gin_lb:gin_lb
+
 regions:
   navigation: 'Navigation'
   navigation_collapsible: 'Navigation (Collapsible)'

--- a/src/HookHandler/GinLayoutBuilder.php
+++ b/src/HookHandler/GinLayoutBuilder.php
@@ -64,8 +64,8 @@ class GinLayoutBuilder implements ContainerInjectionInterface {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container): static {
-    return new static(
+  public static function create(ContainerInterface $container): self {
+    return new self(
       $container->get('module_handler'),
       $container->get('theme_handler')
     );


### PR DESCRIPTION
## Description
Teamwork Ticket(s): https://kanopi.teamwork.com/app/tasks/29714324
- [ ] Was AI used in this pull request? Yes

This PR fixes some of the PHPstan errors reported in [issue-26](https://github.com/kanopi/arbor/issues/26).

To fix the remaining PHPstan errors on the ucsf-deb project, I composer required the [mglaman/phpstan-drupal](https://github.com/mglaman/phpstan-drupal) library.

"PHPStan is able to [discover symbols](https://phpstan.org/user-guide/discovering-symbols) by using autoloading provided by Composer. However, Drupal does not provide autoloading information for modules and themes. This project registers those namespaces so that PHPStan can properly discover symbols in your Drupal code base automatically."

## Steps to Validate
1. These changes eliminated the [PHPstan errors](https://app.circleci.com/pipelines/github/kanopi/ucsf-deb/12/workflows/2f359fb9-fcc5-4e56-b03b-2a3fd5a84de1/jobs/113) on the ucsf-deb project. [Here](https://app.circleci.com/pipelines/github/kanopi/ucsf-deb/15/workflows/6a3505e4-a0f1-4d91-8cf6-1f1271945de1) is the successful phpstan test after I made these changes.


